### PR TITLE
Remove unused permission

### DIFF
--- a/HPDark-Chrome/manifest.json
+++ b/HPDark-Chrome/manifest.json
@@ -12,7 +12,6 @@
   },
 
   "permissions": [
-    "activeTab",
     "storage",
     "notifications"
   ],


### PR DESCRIPTION
"activeTab" permission is unused, therefore not needed. Removed.